### PR TITLE
Feature: Poll command

### DIFF
--- a/src/main/kotlin/commands/poll_command.kt
+++ b/src/main/kotlin/commands/poll_command.kt
@@ -20,7 +20,7 @@ class PollCommand : ListenerAdapter() {
         if (event.name != "poll") return
         if (event.guild == null) return
 
-        Poll(event, event.getOption("timeout")?.asLong ?: DEFAULT_POLL_TIMEOUT)
+        Poll(event, event.getOption("timeout")?.asLong ?: DEFAULT_POLL_TIMEOUT).send()
     }
 
 }
@@ -45,10 +45,9 @@ class Poll(
         event.jda.addEventListener(this)
         options = options.ifEmpty { mutableListOf("Oui", "Non") }
         options.forEachIndexed { i, _ -> answers[i] = mutableSetOf() }
-        send()
     }
 
-    private fun send() {
+    fun send() {
         if (question != null) {
             event.replyEmbeds(
                 EmbedBuilder()

--- a/src/main/kotlin/commands/poll_command.kt
+++ b/src/main/kotlin/commands/poll_command.kt
@@ -1,0 +1,119 @@
+package commands
+
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.events.interaction.ButtonClickEvent
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import net.dv8tion.jda.api.interactions.components.ActionRow
+import net.dv8tion.jda.api.interactions.components.Button
+import utils.TaskScheduler
+import utils.pluralize
+import java.awt.Color
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+const val DEFAULT_POLL_TIMEOUT = 2L
+
+class PollCommand : ListenerAdapter() {
+
+    override fun onSlashCommand(event: SlashCommandEvent) {
+        if (event.name != "poll") return
+        if (event.guild == null) return
+
+        Poll(event, event.getOption("timeout")?.asLong ?: DEFAULT_POLL_TIMEOUT)
+    }
+
+}
+
+class Poll(
+    private val event: SlashCommandEvent,
+    private val timeout: Long
+) : ListenerAdapter() {
+
+    private val uniqueId = event.user.id + System.currentTimeMillis().toString()
+    private val answers = mutableMapOf<Int, MutableSet<Long>>()
+    private val question = event.getOption("question")
+
+    private var options = listOfNotNull(
+        event.getOption("first")?.asString,
+        event.getOption("second")?.asString,
+        event.getOption("third")?.asString,
+        event.getOption("fourth")?.asString,
+    )
+
+    init {
+        event.jda.addEventListener(this)
+        options = options.ifEmpty { mutableListOf("Oui", "Non") }
+        options.forEachIndexed { i, _ -> answers[i] = mutableSetOf() }
+        send()
+    }
+
+    private fun send() {
+        if (question != null) {
+            event.replyEmbeds(
+                EmbedBuilder()
+                    .setTitle("Sondage demandé par ${event.member!!.effectiveName}")
+                    .setDescription(question.asString)
+                    .setFooter("Résultats du sondage dans $timeout minute".pluralize(timeout))
+                    .setColor(Color(0x9b59b6))
+                    .apply {
+                        options.forEachIndexed { i, name ->
+                            if (i % 2 != 0) addBlankField(true)
+                            addField("Réponse ${'A' + i}", name, true)
+                        }
+                    }.build()
+            ).addActionRows(ActionRow.of(
+                options.mapIndexed { i, _ -> Button.secondary("$uniqueId.${i}", ('A' + i).toString()) }
+            )).queue {
+                TaskScheduler.later(timeout, TimeUnit.MINUTES) {
+                    sendResults()
+                }
+            }
+        }
+    }
+
+    private fun vote(option: Int, id: Long) {
+        answers.forEach { it.value.remove(id) }
+        answers[option]?.add(id)
+    }
+
+    private fun answerRate(option: Int): Double {
+        val rate = answers[option]?.count()?.div(totalVoteCount().toDouble()) ?: 0.0
+        return if (rate.isNaN()) 0.0 else rate
+    }
+
+    private fun totalVoteCount(): Int = answers.flatMap { it.value }.count()
+
+    private fun sendResults() {
+        event.jda.removeEventListener(this)
+        if (question != null) {
+            event.hook.editOriginalEmbeds(
+                EmbedBuilder()
+                    .setTitle("Sondage demandé par ${event.member!!.effectiveName}")
+                    .setDescription(question.asString)
+                    .setFooter("Sondage terminé (${totalVoteCount()} ${"votant".pluralize(totalVoteCount())})")
+                    .setTimestamp(Instant.now())
+                    .setColor(Color(0x9b59b6))
+                    .apply {
+                        options.forEachIndexed { i, name ->
+                            if (i % 2 != 0) addBlankField(true)
+                            addField(
+                                "Réponse ${'A' + i}",
+                                "**(${"%.2f".format(answerRate(i) * 100)}%)** $name",
+                                true
+                            )
+                        }
+                    }.build()
+            ).queue()
+            event.hook.editOriginalComponents(ActionRow.of(
+                options.mapIndexed { i, _ -> Button.secondary("$uniqueId.${i}", ('A' + i).toString()).asDisabled() }
+            )).queue()
+        }
+    }
+
+    override fun onButtonClick(event: ButtonClickEvent) {
+        if (!event.componentId.startsWith(uniqueId)) return
+        vote(event.componentId.split(".")[1].toInt(), event.user.idLong)
+        event.reply(":white_check_mark: Votre vote a été pris en compte.").setEphemeral(true).queue()
+    }
+}

--- a/src/main/kotlin/commands/poll_command.kt
+++ b/src/main/kotlin/commands/poll_command.kt
@@ -35,10 +35,10 @@ class Poll(
     private val question = event.getOption("question")
 
     private var options = listOfNotNull(
-        event.getOption("first")?.asString,
-        event.getOption("second")?.asString,
-        event.getOption("third")?.asString,
-        event.getOption("fourth")?.asString,
+        event.getOption("a")?.asString,
+        event.getOption("b")?.asString,
+        event.getOption("c")?.asString,
+        event.getOption("d")?.asString,
     )
 
     init {

--- a/src/main/kotlin/core/commands.kt
+++ b/src/main/kotlin/core/commands.kt
@@ -15,6 +15,14 @@ fun JDA.registerGlobalCommands() {
             option(OptionType.INTEGER, name = "timeout", "Temps imparti pour répondre à l'appel en minutes.")
             option(OptionType.ROLE, name = "role", "Groupe d'étudiants visé.")
         }
+        command("poll", "Lancer un sondage dans le salon courant.") {
+            option(OptionType.STRING, name = "question", "Question sur laquelle porte le sondage.", required = true)
+            option(OptionType.INTEGER, name = "timeout", "Temps imparti pour répondre au sondage en minutes. (Défaut = 2 minutes)")
+            option(OptionType.STRING, name = "a", "Première réponse possible.")
+            option(OptionType.STRING, name = "b", "Seconde réponse possible.")
+            option(OptionType.STRING, name = "c", "Troisième réponse possible.")
+            option(OptionType.STRING, name = "d", "Quatrième réponse possible.")
+        }
     }
 }
 
@@ -28,14 +36,6 @@ fun Guild.registerGuildCommands() {
                     }
                 } ?: listOf()
             }
-        }
-        command("poll", "Lancer un sondage dans le salon courant.") {
-            option(OptionType.STRING, name = "question", "Question sur laquelle porte le sondage.", required = true)
-            option(OptionType.INTEGER, name = "timeout", "Temps imparti pour répondre au sondage en minutes. (Défaut = 2 minutes)")
-            option(OptionType.STRING, name = "a", "Première réponse possible.")
-            option(OptionType.STRING, name = "b", "Seconde réponse possible.")
-            option(OptionType.STRING, name = "c", "Troisième réponse possible.")
-            option(OptionType.STRING, name = "d", "Quatrième réponse possible.")
         }
     }
 }

--- a/src/main/kotlin/core/commands.kt
+++ b/src/main/kotlin/core/commands.kt
@@ -32,10 +32,10 @@ fun Guild.registerGuildCommands() {
         command("poll", "Lancer un sondage dans le salon courant.") {
             option(OptionType.STRING, name = "question", "Question sur laquelle porte le sondage.", required = true)
             option(OptionType.INTEGER, name = "timeout", "Temps imparti pour répondre au sondage en minutes. (Défaut = 2 minutes)")
-            option(OptionType.STRING, name = "first", "Première réponse possible.")
-            option(OptionType.STRING, name = "second", "Seconde réponse possible.")
-            option(OptionType.STRING, name = "third", "Troisième réponse possible.")
-            option(OptionType.STRING, name = "fourth", "Quatrième réponse possible.")
+            option(OptionType.STRING, name = "a", "Première réponse possible.")
+            option(OptionType.STRING, name = "b", "Seconde réponse possible.")
+            option(OptionType.STRING, name = "c", "Troisième réponse possible.")
+            option(OptionType.STRING, name = "d", "Quatrième réponse possible.")
         }
     }
 }

--- a/src/main/kotlin/core/commands.kt
+++ b/src/main/kotlin/core/commands.kt
@@ -29,5 +29,13 @@ fun Guild.registerGuildCommands() {
                 } ?: listOf()
             }
         }
+        command("poll", "Lancer un sondage dans le salon courant.") {
+            option(OptionType.STRING, name = "question", "Question sur laquelle porte le sondage.", required = true)
+            option(OptionType.INTEGER, name = "timeout", "Temps imparti pour répondre au sondage en minutes. (Défaut = 2 minutes)")
+            option(OptionType.STRING, name = "first", "Première réponse possible.")
+            option(OptionType.STRING, name = "second", "Seconde réponse possible.")
+            option(OptionType.STRING, name = "third", "Troisième réponse possible.")
+            option(OptionType.STRING, name = "fourth", "Quatrième réponse possible.")
+        }
     }
 }

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -5,6 +5,7 @@ import commands.AutoRoleCommand
 import commands.CallCommand
 import events.loadAutoRoles
 import commands.KevalCommand
+import commands.PollCommand
 import core.clearGuildConfigs
 import core.registerGlobalCommands
 import core.registerGuildCommands
@@ -42,7 +43,7 @@ class UGEBot(token: String) : ListenerAdapter() {
     }
 
     override fun onReady(event: ReadyEvent) {
-        jda.addEventListener(CallCommand(), KevalCommand(), AutoRoleCommand())
+        jda.addEventListener(CallCommand(), KevalCommand(), AutoRoleCommand(), PollCommand())
         load()
     }
 

--- a/src/main/kotlin/utils/strings.kt
+++ b/src/main/kotlin/utils/strings.kt
@@ -1,15 +1,8 @@
 package utils
 
-fun String.pluralize(count: Int) =
+fun String.pluralize(count: Number) =
     pluralize(count, null)
 
-fun String.pluralize(count: Int, form: String?) =
-    if (count > 1) form ?: this + "s"
-    else this
-
-fun String.pluralize(count: Long) =
-    pluralize(count, null)
-
-fun String.pluralize(count: Long, form: String?) =
-    if (count > 1) form ?: this + "s"
+fun String.pluralize(count: Number, form: String?) =
+    if (count.toLong() > 1) form ?: "${this}s"
     else this

--- a/src/main/kotlin/utils/strings.kt
+++ b/src/main/kotlin/utils/strings.kt
@@ -6,3 +6,10 @@ fun String.pluralize(count: Int) =
 fun String.pluralize(count: Int, form: String?) =
     if (count > 1) form ?: this + "s"
     else this
+
+fun String.pluralize(count: Long) =
+    pluralize(count, null)
+
+fun String.pluralize(count: Long, form: String?) =
+    if (count > 1) form ?: this + "s"
+    else this


### PR DESCRIPTION
I added a new client-side command:
```
/poll <question> [timeout] [a] [b] [c] [d]
```

It allows anyone (in the long term only teachers) to quickly create a poll. Everyone can answer to a single option. After timeout hits, the poll is closed and results are displayed in percentages.

If no options are given, the poll is considered as a closed question with only "Yes" or "No" as options.