### PR TITLE
Add temporary channels generators

### DIFF
--- a/src/main/kotlin/commands/changen_command.tk.kt
+++ b/src/main/kotlin/commands/changen_command.tk.kt
@@ -1,0 +1,123 @@
+package commands
+
+import net.dv8tion.jda.api.entities.VoiceChannel
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceJoinEvent
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceLeaveEvent
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceMoveEvent
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.util.*
+import kotlin.concurrent.schedule
+
+const val INITIAL_DELETION_TIMEOUT = 150 * 1000L
+const val IMMINENT_DELETION_TIMEOUT = 30 * 1000L
+
+private val logger: Logger = LoggerFactory.getLogger("TemporaryChannels")
+
+class ChanGenCommand : ListenerAdapter() {
+
+    private val generators: MutableSet<String> = mutableSetOf()
+    private val temporaryChannels: MutableMap<String, String> = mutableMapOf()
+    private val deletionTasks: MutableMap<String, TimerTask> = mutableMapOf()
+
+    init {
+        val file = File("temporaryChannelGenerators")
+        if (file.exists()) {
+            file.readLines().stream().map {
+                it.trim('\n')
+            }.forEach {
+                generators.add(it)
+                logger.info("Successfully created generator on $it")
+            }
+        }
+    }
+
+    override fun onSlashCommand(event: SlashCommandEvent) {
+        if (event.name != "changen") return
+        if (event.guild == null) return
+
+        event.getOption("channel")?.asGuildChannel?.let {
+            if (it.id in generators) {
+                generators.remove(it.id)
+                event.reply(":white_check_mark: Le générateur du salon **${it.name}** a été supprimé.")
+                    .setEphemeral(true)
+                    .queue()
+            } else {
+                generators.add(it.id)
+                event.reply(":white_check_mark: Le salon **${it.name}** a été lié à un générateur.")
+                    .setEphemeral(true)
+                    .queue()
+            }
+            save()
+        }
+    }
+
+    override fun onGuildVoiceJoin(event: GuildVoiceJoinEvent) {
+        val channelJoined = event.channelJoined
+        val member = event.member
+
+        checkJoin(event.channelJoined)
+        if (channelJoined.id !in generators) return
+
+        temporaryChannels[member.id]?.let {
+            member.guild.getVoiceChannelById(it)?.let { channel ->
+                // Member already has a temporary channel, moving them.
+                member.guild.moveVoiceMember(member, channel).queue()
+                return
+            } ?: run {
+                // Previously registered channel no longer exists, removing it.
+                temporaryChannels.remove(member.id)
+            }
+        }
+
+        // Creating new temporary channel for the current member.
+        channelJoined.parent?.createVoiceChannel("\uD83D\uDD35 Salon de ${member.effectiveName}")?.queue() {
+            temporaryChannels[member.id] = it.id
+            member.guild.moveVoiceMember(member, it).queue()
+        }
+    }
+
+    override fun onGuildVoiceLeave(event: GuildVoiceLeaveEvent) {
+        checkLeave(event.channelLeft)
+    }
+
+    override fun onGuildVoiceMove(event: GuildVoiceMoveEvent) {
+        checkJoin(event.channelJoined)
+        checkLeave(event.channelLeft)
+    }
+
+    private fun checkJoin(channel: VoiceChannel) {
+        if (channel.id in deletionTasks.keys) {
+            deletionTasks.remove(channel.id)?.cancel()
+            if (channel.name.startsWith("\uD83D\uDD34")) {
+                channel.manager.setName(channel.name.replace("\uD83D\uDD34", "\uD83D\uDD35")).queue()
+            }
+        }
+    }
+
+    private fun checkLeave(channel: VoiceChannel) {
+        if (channel.id !in temporaryChannels.values) return
+        if (channel.members.size > 0) return
+
+        deletionTasks[channel.id] = Timer().schedule(INITIAL_DELETION_TIMEOUT) {
+            channel.manager.setName(channel.name.replace("\uD83D\uDD35", "\uD83D\uDD34")).queue()
+            deletionTasks[channel.id] = Timer().schedule(IMMINENT_DELETION_TIMEOUT) {
+                channel.delete().queue() {
+                    deletionTasks.remove(channel.id)
+                    temporaryChannels.remove(channel.id)
+                }
+            }
+        }
+    }
+
+    private fun save() {
+        val file = File("temporaryChannelGenerators")
+        if (!file.exists()) file.createNewFile()
+        generators.forEach {
+            file.writeText(it)
+        }
+    }
+}

--- a/src/main/kotlin/commands/changen_command.tk.kt
+++ b/src/main/kotlin/commands/changen_command.tk.kt
@@ -19,18 +19,20 @@ private val logger: Logger = LoggerFactory.getLogger("TemporaryChannels")
 
 class ChanGenCommand : ListenerAdapter() {
 
-    private val generators: MutableSet<String> = mutableSetOf()
-    private val temporaryChannels: MutableMap<String, String> = mutableMapOf()
-    private val deletionTasks: MutableMap<String, TimerTask> = mutableMapOf()
+    private val generators = mutableSetOf<String>()
+    private val temporaryChannels = mutableMapOf<String, String>()
+    private val deletionTasks = mutableMapOf<String, TimerTask>()
 
     init {
         val file = File("temporaryChannelGenerators")
         if (file.exists()) {
-            file.readLines().stream().map {
-                it.trim('\n')
-            }.forEach {
-                generators.add(it)
-                logger.info("Successfully created generator on $it")
+            file.useLines { lines ->
+                lines.map {
+                    it.trim('\n')
+                }.forEach {
+                    generators.add(it)
+                    logger.info("Successfully created generator on $it")
+                }
             }
         }
     }
@@ -39,15 +41,15 @@ class ChanGenCommand : ListenerAdapter() {
         if (event.name != "changen") return
         if (event.guild == null) return
 
-        event.getOption("channel")?.asGuildChannel?.let {
-            if (it.id in generators) {
-                generators.remove(it.id)
-                event.reply(":white_check_mark: Le générateur du salon **${it.name}** a été supprimé.")
+        event.getOption("channel")?.asGuildChannel?.let { channel ->
+            if (channel.id in generators) {
+                generators.remove(channel.id)
+                event.reply(":white_check_mark: Le générateur du salon **${channel.name}** a été supprimé.")
                     .setEphemeral(true)
                     .queue()
             } else {
-                generators.add(it.id)
-                event.reply(":white_check_mark: Le salon **${it.name}** a été lié à un générateur.")
+                generators.add(channel.id)
+                event.reply(":white_check_mark: Le salon **${channel.name}** a été lié à un générateur.")
                     .setEphemeral(true)
                     .queue()
             }

--- a/src/main/kotlin/commands/changen_command.tk.kt
+++ b/src/main/kotlin/commands/changen_command.tk.kt
@@ -76,7 +76,7 @@ class ChanGenCommand : ListenerAdapter() {
         }
 
         // Creating new temporary channel for the current member.
-        channelJoined.parent?.createVoiceChannel("\uD83D\uDD35 Salon de ${member.effectiveName}")?.queue() {
+        channelJoined.parent?.createVoiceChannel("\uD83D\uDD35 Salon de ${member.effectiveName}")?.queue {
             temporaryChannels[member.id] = it.id
             member.guild.moveVoiceMember(member, it).queue()
         }
@@ -107,7 +107,7 @@ class ChanGenCommand : ListenerAdapter() {
         deletionTasks[channel.id] = Timer().schedule(INITIAL_DELETION_TIMEOUT) {
             channel.manager.setName(channel.name.replace("\uD83D\uDD35", "\uD83D\uDD34")).queue()
             deletionTasks[channel.id] = Timer().schedule(IMMINENT_DELETION_TIMEOUT) {
-                channel.delete().queue() {
+                channel.delete().queue {
                     deletionTasks.remove(channel.id)
                     temporaryChannels.remove(channel.id)
                 }

--- a/src/main/kotlin/core/commands.kt
+++ b/src/main/kotlin/core/commands.kt
@@ -23,6 +23,9 @@ fun JDA.registerGlobalCommands() {
             option(OptionType.STRING, name = "c", "Troisième réponse possible.")
             option(OptionType.STRING, name = "d", "Quatrième réponse possible.")
         }
+        command("changen", "Lier un salon à un générateur de salons temporaires.") {
+            option(OptionType.CHANNEL, name = "channel", "Salon qui servira de point de départ.", required = true)
+        }
     }
 }
 

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -1,10 +1,7 @@
 import com.natpryce.konfig.ConfigurationProperties
 import com.natpryce.konfig.Key
 import com.natpryce.konfig.stringType
-import commands.AutoRoleCommand
-import commands.CallCommand
-import commands.KevalCommand
-import commands.PollCommand
+import commands.*
 import core.clearGuildConfigs
 import core.registerGlobalCommands
 import core.registerGuildCommands
@@ -56,7 +53,13 @@ class UGEBot(token: String) : ListenerAdapter() {
     }
 
     override fun onReady(event: ReadyEvent) {
-        jda.addEventListener(CallCommand(), KevalCommand(), AutoRoleCommand(), PollCommand())
+        jda.addEventListener(
+            CallCommand(),
+            KevalCommand(),
+            AutoRoleCommand(),
+            PollCommand(),
+            ChanGenCommand()
+        )
         load()
     }
 


### PR DESCRIPTION
This feature allows staff so assign channels generators to given channels using the `/changen` command. To remove a generator, simply run the command again on the same channel.

These channels generators can then be used by users to create a temporary channel to work with mates. 

Once a channel gets empty, the bot waits 2min30s then changes the blue dot on the channel name to a red dot to warn the upcoming deletion of the channel (30s). If anybody joins the channel whilst the bot is waiting to delete it, the scheduled deletion is canceled and the cycle starts over.