### PR TITLE
`repeat()` method in TaskScheduler

### DIFF
--- a/src/main/kotlin/io/slama/utils/task_scheduler.kt
+++ b/src/main/kotlin/io/slama/utils/task_scheduler.kt
@@ -19,10 +19,9 @@ object TaskScheduler {
             block()
         }
 
-    fun repeat(period: Long, unit: TimeUnit, block: () -> Unit) =
+    fun repeat(period: Long, unit: TimeUnit, block: () -> Boolean) =
         CoroutineScope(Dispatchers.IO).launch {
-            while (true) {
-                block()
+            while (block()) {
                 delay(unit.toMillis(period))
             }
         }

--- a/src/main/kotlin/io/slama/utils/task_scheduler.kt
+++ b/src/main/kotlin/io/slama/utils/task_scheduler.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
 
 object TaskScheduler {
+
     fun later(delay: Long, unit: TimeUnit, block: () -> Unit) =
         CoroutineScope(Dispatchers.IO).launch {
             delay(unit.toMillis(delay))
@@ -16,5 +17,13 @@ object TaskScheduler {
     fun async(block: () -> Unit) =
         CoroutineScope(Dispatchers.IO).launch {
             block()
+        }
+
+    fun repeat(period: Long, unit: TimeUnit, block: () -> Unit) =
+        CoroutineScope(Dispatchers.IO).launch {
+            while (true) {
+                block()
+                delay(unit.toMillis(period))
+            }
         }
 }


### PR DESCRIPTION
I added a way to make the bot repeat a task indefinitely and asynchronously. I need this to be approved ASAP to introduce presence messages.