### PR TITLE
Add shortcuts to reply success, warning or error

### DIFF
--- a/src/main/kotlin/io/slama/utils/replies.kt
+++ b/src/main/kotlin/io/slama/utils/replies.kt
@@ -8,12 +8,16 @@ import net.dv8tion.jda.api.requests.restaction.MessageAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction
 import java.awt.Color
 
+val GREEN = Color(0x2ecc71)
+val YELLOW = Color(0xf1c40f)
+val RED = Color(0xe74c3c)
+
 fun SlashCommandEvent.replySuccess(message: String): ReplyAction {
     return this.replyEmbeds(
         EmbedBuilder()
             .setTitle("Succès")
             .setDescription(message)
-            .setColor(Color(0x2ecc71))
+            .setColor(GREEN)
             .build()
     )
 }
@@ -23,7 +27,7 @@ fun MessageChannel.sendSuccess(message: String): MessageAction {
         EmbedBuilder()
             .setTitle("Succès")
             .setDescription(message)
-            .setColor(Color(0x2ecc71))
+            .setColor(GREEN)
             .build()
     )
 }
@@ -33,7 +37,7 @@ fun SlashCommandEvent.replyWarning(message: String): ReplyAction {
         EmbedBuilder()
             .setTitle("Avertissement")
             .setDescription(message)
-            .setColor(Color(0xf1c40f))
+            .setColor(YELLOW)
             .build()
     )
 }
@@ -43,7 +47,7 @@ fun MessageChannel.sendWarning(message: String): MessageAction {
         EmbedBuilder()
             .setTitle("Avertissement")
             .setDescription(message)
-            .setColor(Color(0xf1c40f))
+            .setColor(YELLOW)
             .build()
     )
 }
@@ -53,7 +57,7 @@ fun SlashCommandEvent.replyError(message: String): ReplyAction {
         EmbedBuilder()
             .setTitle("Erreur")
             .setDescription(message)
-            .setColor(Color(0xe74c3c))
+            .setColor(RED)
             .build()
     )
 }
@@ -63,7 +67,7 @@ fun MessageChannel.sendError(message: String): MessageAction {
         EmbedBuilder()
             .setTitle("Erreur")
             .setDescription(message)
-            .setColor(Color(0xe74c3c))
+            .setColor(RED)
             .build()
     )
 }

--- a/src/main/kotlin/io/slama/utils/replies.kt
+++ b/src/main/kotlin/io/slama/utils/replies.kt
@@ -1,0 +1,36 @@
+package io.slama.utils
+
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction
+import java.awt.Color
+
+fun SlashCommandEvent.replySuccess(message: String): ReplyAction {
+    return this.replyEmbeds(
+        EmbedBuilder()
+            .setTitle("Succès")
+            .setDescription(message)
+            .setColor(Color(0x2ecc71))
+            .build()
+    )
+}
+
+fun SlashCommandEvent.replyWarning(message: String): ReplyAction {
+    return this.replyEmbeds(
+        EmbedBuilder()
+            .setTitle("Avertissement")
+            .setDescription(message)
+            .setColor(Color(0xf1c40f))
+            .build()
+    )
+}
+
+fun SlashCommandEvent.replyError(message: String): ReplyAction {
+    return this.replyEmbeds(
+        EmbedBuilder()
+            .setTitle("Erreur")
+            .setDescription(message)
+            .setColor(Color(0xe74c3c))
+            .build()
+    )
+}

--- a/src/main/kotlin/io/slama/utils/replies.kt
+++ b/src/main/kotlin/io/slama/utils/replies.kt
@@ -1,12 +1,25 @@
 package io.slama.utils
 
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageChannel
+import net.dv8tion.jda.api.entities.TextChannel
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent
+import net.dv8tion.jda.api.requests.restaction.MessageAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction
 import java.awt.Color
 
 fun SlashCommandEvent.replySuccess(message: String): ReplyAction {
     return this.replyEmbeds(
+        EmbedBuilder()
+            .setTitle("Succès")
+            .setDescription(message)
+            .setColor(Color(0x2ecc71))
+            .build()
+    )
+}
+
+fun MessageChannel.sendSuccess(message: String): MessageAction {
+    return this.sendMessage(
         EmbedBuilder()
             .setTitle("Succès")
             .setDescription(message)
@@ -25,8 +38,28 @@ fun SlashCommandEvent.replyWarning(message: String): ReplyAction {
     )
 }
 
+fun MessageChannel.sendWarning(message: String): MessageAction {
+    return this.sendMessage(
+        EmbedBuilder()
+            .setTitle("Avertissement")
+            .setDescription(message)
+            .setColor(Color(0xf1c40f))
+            .build()
+    )
+}
+
 fun SlashCommandEvent.replyError(message: String): ReplyAction {
     return this.replyEmbeds(
+        EmbedBuilder()
+            .setTitle("Erreur")
+            .setDescription(message)
+            .setColor(Color(0xe74c3c))
+            .build()
+    )
+}
+
+fun MessageChannel.sendError(message: String): MessageAction {
+    return this.sendMessage(
         EmbedBuilder()
             .setTitle("Erreur")
             .setDescription(message)


### PR DESCRIPTION
I added idiomatic extension methods to quickly reply to a `SlashCommandEvent`. Here's an example:
```kt
fun command(event: SlashCommandEvent) {
  event.replyError("Command is not working yet!").queue()
}
```
![image](https://user-images.githubusercontent.com/13136802/132494362-59036c17-2263-4916-a7bd-54c015843539.png)
