### PR TITLE
Config rework, full reload, and missing folders

### DIFF
--- a/src/main/kotlin/io/slama/commands/call_command.kt
+++ b/src/main/kotlin/io/slama/commands/call_command.kt
@@ -1,5 +1,6 @@
 package io.slama.commands
 
+import io.slama.core.BotConfiguration
 import io.slama.core.ConfigFolders
 import io.slama.utils.EmbedColors
 import io.slama.utils.TaskScheduler
@@ -71,6 +72,11 @@ private class Call(
         val df = SimpleDateFormat("yyyy.MM.dd-HH.mm.ss")
         val hdf = SimpleDateFormat("dd/MM/yyyy à HH:mm")
         val fileName = "call_${event.member?.effectiveName ?: "anonymous"}_#${event.textChannel.name}_${df.format(calendar.time)}.txt"
+
+        with(File(ConfigFolders.CALLS_DATA_ROOT)) {
+            if (!exists() || !isDirectory)
+                BotConfiguration.resetConfig()
+        }
 
         File(ConfigFolders.CALLS_DATA_ROOT, fileName).apply {
             if (!createNewFile()) {

--- a/src/main/kotlin/io/slama/commands/poll_command.kt
+++ b/src/main/kotlin/io/slama/commands/poll_command.kt
@@ -1,5 +1,6 @@
 package io.slama.commands
 
+import io.slama.core.BotConfiguration
 import io.slama.core.ConfigFolders
 import io.slama.utils.EmbedColors
 import io.slama.utils.TaskScheduler
@@ -142,6 +143,11 @@ class Poll(
         val df = SimpleDateFormat("yyyy.MM.dd-HH.mm.ss")
         val hdf = SimpleDateFormat("dd/MM/yyyy à HH:mm")
         val fileName = "poll_${event.member?.effectiveName ?: "anonymous"}_#${event.textChannel.name}_${df.format(calendar.time)}.txt"
+
+        with(File(ConfigFolders.POLLS_DATA_ROOT)) {
+            if (!exists() || !isDirectory)
+                BotConfiguration.resetConfig()
+        }
 
         File(ConfigFolders.POLLS_DATA_ROOT, fileName).apply {
             if (!createNewFile()) {

--- a/src/main/kotlin/io/slama/commands/table_command.kt
+++ b/src/main/kotlin/io/slama/commands/table_command.kt
@@ -221,7 +221,7 @@ class ASCIITable {
     }
 
     /**
-     * @return the char at the intersection of the north west edge of the cell at [`row`, `col`].
+     * @return the char at the intersection of the north-west edge of the cell at [`row`, `col`].
      */
     private fun getIntersect(row: Int, col: Int): Char {
         val up = if (empty(row - 1, col - 1) && empty(row - 1, col)) 0 else 1

--- a/src/main/kotlin/io/slama/core/commands.kt
+++ b/src/main/kotlin/io/slama/core/commands.kt
@@ -47,7 +47,7 @@ fun Guild.registerGuildCommands() {
     this {
         command("autorole", "Créer un attributeur automatique de rôle.") {
             option(OptionType.STRING, name = "name", "Nom de l'attributeur.") {
-                this@registerGuildCommands.getConfigOrNull()?.let {
+                BotConfiguration.guilds[this@registerGuildCommands.idLong]?.let {
                     it.autoRoles.keys.map { name ->
                         Command.Choice(name, name)
                     }

--- a/src/main/kotlin/io/slama/core/config.kt
+++ b/src/main/kotlin/io/slama/core/config.kt
@@ -46,14 +46,13 @@ class BotConfiguration private constructor() {
 
         private var innerConfig: BotConfiguration? = null
             get() {
-                if (field == null) {
-                    setupDir()
+                if (field == null)
                     field = BotConfiguration()
-                }
                 return field
             }
 
         fun resetConfig() {
+            setupDir()
             innerConfig = null
         }
 
@@ -154,6 +153,10 @@ class BotConfiguration private constructor() {
 
         @OptIn(ExperimentalSerializationApi::class)
         private fun loadConfig(guildId: Long) {
+            with(File(GUILD_CONFIG_ROOT)) {
+                if (!exists() || !isDirectory)
+                    resetConfig()
+            }
             File("$GUILD_CONFIG_ROOT$guildId").run {
                 mkdir()
                 if (!this.isDirectory)
@@ -188,6 +191,10 @@ class BotConfiguration private constructor() {
     @OptIn(ExperimentalSerializationApi::class)
     private val shusherConfig: ShusherConfig
         get() {
+            with(File(CONFIG_ROOT)) {
+                if (!exists() || !isDirectory)
+                    resetConfig()
+            }
             val shusherF = File("${CONFIG_ROOT}shusher.json")
             if (!shusherF.exists()) {
                 createShusherFile(shusherF)
@@ -198,6 +205,10 @@ class BotConfiguration private constructor() {
     @OptIn(ExperimentalSerializationApi::class)
     private val presenceConfig: PresenceConfig
         get() {
+            with(File(CONFIG_ROOT)) {
+                if (!exists() || !isDirectory)
+                    resetConfig()
+            }
             val presenceF = File("${CONFIG_ROOT}presence.json")
             if (!presenceF.exists()) {
                 createPresenceFile(presenceF)

--- a/src/main/kotlin/io/slama/core/config.kt
+++ b/src/main/kotlin/io/slama/core/config.kt
@@ -11,7 +11,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import net.dv8tion.jda.api.entities.Activity
-import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.interactions.components.ButtonStyle
 import java.io.File
 import java.io.IOException
@@ -25,40 +24,186 @@ object ConfigFolders {
     const val GUILD_CONFIG_ROOT = "${CONFIG_ROOT}guilds/"
 }
 
-private val guildConfigs: MutableMap<Long, GuildConfig> = mutableMapOf()
+class BotConfiguration private constructor() {
+    companion object {
+        val guilds: GuildConfigManager
+            get() = innerConfig!!.guildConfigs /*
+            Explicitly want an NPE if it's null here,
+            because it can only happen if the JVM is literally dying
+            */
 
-fun configSetup() {
-    with(File(BOT_PROPERTIES)) {
-        if (!exists())
-            writeText("token=0\n")
-        else if (!isFile)
-            throw IOException("Couldn't create a $BOT_PROPERTIES file.")
-    }
-    with(File(CONFIG_ROOT)) {
-        mkdir()
-        if (!isDirectory) throw IOException("Couldn't create the $CONFIG_ROOT directory.")
-        else with(File(GUILD_CONFIG_ROOT)) {
-            mkdir()
-            if (!isDirectory)
-                throw IOException("Couldn't create the $GUILD_CONFIG_ROOT directory.")
+        val shusher: ShusherConfig
+            get() = innerConfig!!.shusherConfig /*
+            Explicitly want an NPE if it's null here,
+            because it can only happen if the JVM is literally dying
+            */
+
+        val presence: PresenceConfig
+            get() = innerConfig!!.presenceConfig /*
+            Explicitly want an NPE if it's null here,
+            because it can only happen if the JVM is literally dying
+            */
+
+        private var innerConfig: BotConfiguration? = null
+            get() {
+                if (field == null) {
+                    setupDir()
+                    field = BotConfiguration()
+                }
+                return field
+            }
+
+        fun resetConfig() {
+            innerConfig = null
         }
 
-
-    }
-    with(File(DATA_ROOT)) {
-        mkdir()
-        if (!this.isDirectory) throw IOException("Couldn't create the $DATA_ROOT directory.")
-        else {
-            with(File(CALLS_DATA_ROOT)) {
-                mkdir()
-                if (!this.isDirectory) throw IOException("Couldn't create the $CALLS_DATA_ROOT directory.")
+        private fun setupDir() {
+            with(File(BOT_PROPERTIES)) {
+                if (!exists())
+                    writeText("token=0\n")
+                else if (!isFile)
+                    throw IOException("Couldn't create a $BOT_PROPERTIES file.")
             }
-            with(File(POLLS_DATA_ROOT)) {
+            with(File(CONFIG_ROOT)) {
                 mkdir()
-                if (!this.isDirectory) throw IOException("Couldn't create the $POLLS_DATA_ROOT directory.")
+                if (!isDirectory) throw IOException("Couldn't create the $CONFIG_ROOT directory.")
+                else with(File(GUILD_CONFIG_ROOT)) {
+                    mkdir()
+                    if (!isDirectory)
+                        throw IOException("Couldn't create the $GUILD_CONFIG_ROOT directory.")
+                }
+
+
+            }
+            with(File(DATA_ROOT)) {
+                mkdir()
+                if (!this.isDirectory) throw IOException("Couldn't create the $DATA_ROOT directory.")
+                else {
+                    with(File(CALLS_DATA_ROOT)) {
+                        mkdir()
+                        if (!this.isDirectory) throw IOException("Couldn't create the $CALLS_DATA_ROOT directory.")
+                    }
+                    with(File(POLLS_DATA_ROOT)) {
+                        mkdir()
+                        if (!this.isDirectory) throw IOException("Couldn't create the $POLLS_DATA_ROOT directory.")
+                    }
+                }
             }
         }
+
+        private fun createRolesFile(file: File) {
+            file.createNewFile()
+            file.writeText("""
+                {
+                  "adminRoleID": 0,
+                  "managerRoleID": 1,
+                  "teacherRoleID": 2,
+                  "studentRoleID": 3
+                }
+            """.trimIndent())
+        }
+
+        private fun createChannelsFile(file: File) {
+            file.createNewFile()
+            file.writeText("""
+                {
+                  "announcementsChannelID": 0,
+                  "moodleAnnouncementsChannelsIDs": {
+                  }
+                }
+            """.trimIndent())
+        }
+
+        private fun createAutorolesFile(file: File) {
+            file.createNewFile()
+            file.writeText("{}\n")
+        }
+
+        private fun createShusherFile(file: File) {
+            file.createNewFile()
+            file.writeText("""
+                {
+                  "sentences": [
+                    "Please stop talking..."
+                  ]
+                }
+            """.trimIndent())
+        }
+
+        private fun createPresenceFile(file: File) {
+            file.createNewFile()
+            file.writeText("""
+                {
+                  "messages": {
+                    "something": "DEFAULT",
+                    "something else": "WATCHING",
+                    "some other thing": "LISTENING"
+                  }
+                }
+            """.trimIndent())
+        }
     }
+
+    class GuildConfigManager {
+        private val guildConfigsMap: MutableMap<Long, GuildConfig> = mutableMapOf()
+
+        operator fun get(guildId: Long): GuildConfig? {
+            if (guildId !in guildConfigsMap.keys) loadConfig(guildId)
+            return guildConfigsMap[guildId]
+        }
+
+        @OptIn(ExperimentalSerializationApi::class)
+        private fun loadConfig(guildId: Long) {
+            File("$GUILD_CONFIG_ROOT$guildId").run {
+                mkdir()
+                if (!this.isDirectory)
+                    throw IOException("Couldn't create the $name directory as there is already a file named like that.")
+            }
+
+            val rolesF = File("$GUILD_CONFIG_ROOT$guildId/roles.json")
+            if (!rolesF.exists()) {
+                createRolesFile(rolesF)
+            }
+
+            val channelsF = File("$GUILD_CONFIG_ROOT$guildId/channels.json")
+            if (!channelsF.exists()) {
+                createChannelsFile(channelsF)
+            }
+
+            val autorolesF = File("$GUILD_CONFIG_ROOT$guildId/autoroles.json")
+            if (!autorolesF.exists()) {
+                createAutorolesFile(autorolesF)
+            }
+
+            guildConfigsMap[guildId] = GuildConfig(
+                Json.decodeFromString(rolesF.readText()),
+                Json.decodeFromString(channelsF.readText()),
+                Json.decodeFromString(autorolesF.readText()),
+            )
+        }
+    }
+
+    private val guildConfigs = GuildConfigManager()
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private val shusherConfig: ShusherConfig
+        get() {
+            val shusherF = File("${CONFIG_ROOT}shusher.json")
+            if (!shusherF.exists()) {
+                createShusherFile(shusherF)
+            }
+            return Json.decodeFromString(shusherF.readText())
+        }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private val presenceConfig: PresenceConfig
+        get() {
+            val presenceF = File("${CONFIG_ROOT}presence.json")
+            if (!presenceF.exists()) {
+                createPresenceFile(presenceF)
+            }
+            return Json.decodeFromString(presenceF.readText())
+        }
 }
 
 @Serializable
@@ -93,12 +238,12 @@ data class AutoRoleDTO(
 )
 
 @Serializable
-data class ShusherDTO(
+data class ShusherConfig(
     val sentences: List<String>
 )
 
 @Serializable
-data class PresenceDTO(
+data class PresenceConfig(
     val messages: Map<String, Activity.ActivityType>
 )
 
@@ -107,122 +252,3 @@ data class GuildConfig(
     val channels: ChannelsDTO,
     val autoRoles: Map<String, AutoRoleDTO>
 )
-
-fun getConfigOrNull(guildId: Long): GuildConfig? {
-    if (guildId !in guildConfigs.keys) loadConfig(guildId)
-    return guildConfigs[guildId]
-}
-
-fun Guild.getConfigOrNull(): GuildConfig? = getConfigOrNull(this.idLong)
-
-fun clearGuildConfigs() {
-    guildConfigs.clear()
-}
-
-private fun createRolesFile(file: File) {
-    file.createNewFile()
-    file.writeText(
-        """
-        {
-          "adminRoleID": 0,
-          "managerRoleID": 1,
-          "teacherRoleID": 2,
-          "studentRoleID": 3
-        }
-    """.trimIndent()
-    )
-}
-
-private fun createChannelsFile(file: File) {
-    file.createNewFile()
-    file.writeText(
-        """
-        {
-          "announcementsChannelID": 0,
-          "moodleAnnouncementsChannelsIDs": {
-          }
-        }
-    """.trimIndent()
-    )
-}
-
-private fun createAutorolesFile(file: File) {
-    file.createNewFile()
-    file.writeText("{}\n")
-}
-
-private fun createShusherFile(file: File) {
-    file.createNewFile()
-    file.writeText(
-        """
-        {
-          "sentences": [
-            "Please stop talking..."
-          ]
-        }
-    """.trimIndent()
-    )
-}
-
-private fun createPresenceFile(file: File) {
-    file.createNewFile()
-    file.writeText(
-        """
-        {
-          "messages": {
-            "something": "DEFAULT",
-            "something else": "WATCHING",
-            "some other thing": "LISTENING"
-          }
-        }
-    """.trimIndent()
-    )
-}
-
-@OptIn(ExperimentalSerializationApi::class)
-private fun loadConfig(guildId: Long) {
-    File("$GUILD_CONFIG_ROOT$guildId").run {
-        mkdir()
-        if (!this.isDirectory)
-            throw IOException("Couldn't create the $name directory as there is already a file named like that.")
-    }
-
-    val rolesF = File("$GUILD_CONFIG_ROOT$guildId/roles.json")
-    if (!rolesF.exists()) {
-        createRolesFile(rolesF)
-    }
-
-    val channelsF = File("$GUILD_CONFIG_ROOT$guildId/channels.json")
-    if (!channelsF.exists()) {
-        createChannelsFile(channelsF)
-    }
-
-    val autorolesF = File("$GUILD_CONFIG_ROOT$guildId/autoroles.json")
-    if (!autorolesF.exists()) {
-        createAutorolesFile(autorolesF)
-    }
-
-    guildConfigs[guildId] = GuildConfig(
-        Json.decodeFromString(rolesF.readText()),
-        Json.decodeFromString(channelsF.readText()),
-        Json.decodeFromString(autorolesF.readText()),
-    )
-}
-
-@OptIn(ExperimentalSerializationApi::class)
-fun getShusherConfig(): ShusherDTO {
-    val shusherF = File("${CONFIG_ROOT}shusher.json")
-    if (!shusherF.exists()) {
-        createShusherFile(shusherF)
-    }
-    return Json.decodeFromString(shusherF.readText())
-}
-
-@OptIn(ExperimentalSerializationApi::class)
-fun getPresenceConfig(): PresenceDTO {
-    val presenceF = File("${CONFIG_ROOT}presence.json")
-    if (!presenceF.exists()) {
-        createPresenceFile(presenceF)
-    }
-    return Json.decodeFromString(presenceF.readText())
-}

--- a/src/main/kotlin/io/slama/events/autoroles.kt
+++ b/src/main/kotlin/io/slama/events/autoroles.kt
@@ -1,7 +1,7 @@
 package io.slama.events
 
 import io.slama.core.AutoRoleDTO
-import io.slama.core.getConfigOrNull
+import io.slama.core.BotConfiguration
 import io.slama.utils.replyError
 import io.slama.utils.replySuccess
 import net.dv8tion.jda.api.EmbedBuilder
@@ -91,13 +91,13 @@ fun Guild.createAutoRoleIfAbsent(name: String, config: AutoRoleDTO): AutoRole? {
 }
 
 fun Guild.createAutoRoleIfAbsent(name: String): AutoRole? {
-    val config = getConfigOrNull() ?: return null
+    val config = BotConfiguration.guilds[idLong] ?: return null
     val autoRoleDTO = config.autoRoles[name] ?: return null
     return createAutoRoleIfAbsent(name, autoRoleDTO)
 }
 
 fun Guild.loadAutoRoles() {
-    val config = getConfigOrNull() ?: return
+    val config = BotConfiguration.guilds[idLong] ?: return
     config.autoRoles.forEach { (name, autoRole) ->
         createAutoRoleIfAbsent(name, autoRole)
     }

--- a/src/main/kotlin/io/slama/events/shusher.kt
+++ b/src/main/kotlin/io/slama/events/shusher.kt
@@ -24,7 +24,6 @@ class Shusher(
 
     private val roles = mutableMapOf<String, String>()
     private val random = Random(System.currentTimeMillis())
-    private val config = BotConfiguration.shusher
 
     init {
         jda.addEventListener(this)
@@ -50,7 +49,7 @@ class Shusher(
 
             if (member.roles.map { it.id }.any { roles[event.guild.id] == it }) {
                 if (random.nextFloat() <= SHUSHER_TRIGGER_THRESHOLD) {
-                    event.channel.sendMessage(config.sentences.random()).queue()
+                    event.channel.sendMessage(BotConfiguration.shusher.sentences.random()).queue()
                 }
             }
         }

--- a/src/main/kotlin/io/slama/events/shusher.kt
+++ b/src/main/kotlin/io/slama/events/shusher.kt
@@ -1,7 +1,7 @@
 package io.slama.events
 
+import io.slama.core.BotConfiguration
 import io.slama.core.ConfigFolders
-import io.slama.core.getShusherConfig
 import io.slama.utils.isAdmin
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
@@ -24,7 +24,7 @@ class Shusher(
 
     private val roles = mutableMapOf<String, String>()
     private val random = Random(System.currentTimeMillis())
-    private val config = getShusherConfig()
+    private val config = BotConfiguration.shusher
 
     init {
         jda.addEventListener(this)

--- a/src/main/kotlin/io/slama/main.kt
+++ b/src/main/kotlin/io/slama/main.kt
@@ -40,8 +40,6 @@ class UGEBot(token: String) : ListenerAdapter() {
         .enableIntents(GatewayIntent.GUILD_MEMBERS)
         .build()
 
-    private val presenceConfig = BotConfiguration.presence
-
     init {
         while (true) {
             val command = readLine()?.split(" ") ?: listOf("default")
@@ -50,7 +48,7 @@ class UGEBot(token: String) : ListenerAdapter() {
                     jda.shutdown()
                     exitProcess(0)
                 }
-                "reload", "reset" -> BotConfiguration.resetConfig()
+                "reload", "reset" -> load()
                 "delete-commands" -> {
                     if (command.size < 2) continue
                     command.drop(1).forEach { name ->
@@ -79,15 +77,15 @@ class UGEBot(token: String) : ListenerAdapter() {
         Shusher(jda)
         load()
         TaskScheduler.repeat(10, TimeUnit.MINUTES) {
-            val (message, type) = presenceConfig.messages.entries.random()
+            val (message, type) = BotConfiguration.presence.messages.entries.random()
             jda.presence.setPresence(Activity.of(type, message), false)
             true
         }
     }
 
     private fun load() {
-        clearAutoRoles()
         BotConfiguration.resetConfig()
+        clearAutoRoles()
         jda.registerGlobalCommands()
         jda.guilds.forEach {
             it.loadAutoRoles()

--- a/src/main/kotlin/io/slama/main.kt
+++ b/src/main/kotlin/io/slama/main.kt
@@ -50,7 +50,7 @@ class UGEBot(token: String) : ListenerAdapter() {
                     jda.shutdown()
                     exitProcess(0)
                 }
-                "reset" -> BotConfiguration.resetConfig()
+                "reload", "reset" -> BotConfiguration.resetConfig()
                 "delete-commands" -> {
                     if (command.size < 2) continue
                     command.drop(1).forEach { name ->
@@ -124,6 +124,7 @@ class UGEBot(token: String) : ListenerAdapter() {
 }
 
 fun main() {
+    BotConfiguration.resetConfig()
     with(ConfigurationProperties.fromFile(File("bot.properties"))) {
         UGEBot(this[token])
     }

--- a/src/main/kotlin/io/slama/main.kt
+++ b/src/main/kotlin/io/slama/main.kt
@@ -3,10 +3,13 @@ package io.slama
 import com.natpryce.konfig.ConfigurationProperties
 import com.natpryce.konfig.Key
 import com.natpryce.konfig.stringType
-import io.slama.commands.*
-import io.slama.core.clearGuildConfigs
-import io.slama.core.configSetup
-import io.slama.core.getPresenceConfig
+import io.slama.commands.AutoRoleCommand
+import io.slama.commands.CallCommand
+import io.slama.commands.ChanGenCommand
+import io.slama.commands.KevalCommand
+import io.slama.commands.PollCommand
+import io.slama.commands.TableCommand
+import io.slama.core.BotConfiguration
 import io.slama.core.registerGlobalCommands
 import io.slama.core.registerGuildCommands
 import io.slama.events.Shusher
@@ -37,7 +40,7 @@ class UGEBot(token: String) : ListenerAdapter() {
         .enableIntents(GatewayIntent.GUILD_MEMBERS)
         .build()
 
-    private val presenceConfig = getPresenceConfig()
+    private val presenceConfig = BotConfiguration.presence
 
     init {
         while (true) {
@@ -47,7 +50,7 @@ class UGEBot(token: String) : ListenerAdapter() {
                     jda.shutdown()
                     exitProcess(0)
                 }
-                "reload" -> load()
+                "reset" -> BotConfiguration.resetConfig()
                 "delete-commands" -> {
                     if (command.size < 2) continue
                     command.drop(1).forEach { name ->
@@ -84,7 +87,7 @@ class UGEBot(token: String) : ListenerAdapter() {
 
     private fun load() {
         clearAutoRoles()
-        clearGuildConfigs()
+        BotConfiguration.resetConfig()
         jda.registerGlobalCommands()
         jda.guilds.forEach {
             it.loadAutoRoles()
@@ -121,7 +124,6 @@ class UGEBot(token: String) : ListenerAdapter() {
 }
 
 fun main() {
-    configSetup()
     with(ConfigurationProperties.fromFile(File("bot.properties"))) {
         UGEBot(this[token])
     }

--- a/src/main/kotlin/io/slama/utils/command_permissions.kt
+++ b/src/main/kotlin/io/slama/utils/command_permissions.kt
@@ -1,24 +1,24 @@
 package io.slama.utils
 
-import io.slama.core.getConfigOrNull
+import io.slama.core.BotConfiguration
 import net.dv8tion.jda.api.entities.Member
 
 fun Member.isAdmin(): Boolean =
-    guild.getConfigOrNull()?.let { config ->
+    BotConfiguration.guilds[guild.idLong]?.let { config ->
         roles.map { it.idLong }.any { it == config.roles.adminRoleID }
     } ?: false
 
 fun Member.isManager(): Boolean =
-    isAdmin() || guild.getConfigOrNull()?.let { config ->
+    isAdmin() || BotConfiguration.guilds[guild.idLong]?.let { config ->
         roles.map { it.idLong }.any { it == config.roles.managerRoleID }
     } ?: false
 
 fun Member.isTeacher(): Boolean =
-    isManager() || guild.getConfigOrNull()?.let { config ->
+    isManager() || BotConfiguration.guilds[guild.idLong]?.let { config ->
         roles.map { it.idLong }.any { it == config.roles.teacherRoleID }
     } ?: false
 
 fun Member.isStudent(): Boolean =
-    guild.getConfigOrNull()?.let { config ->
+    BotConfiguration.guilds[guild.idLong]?.let { config ->
         roles.map { it.idLong }.any { it == config.roles.studentRoleID }
     } ?: false


### PR DESCRIPTION
- The configuration engine has been completely reworked and rendered opaque. This implies better control over it, and better safety.
- Reload is now complete (guilds, presence, shusher) with the local commands `reload` or `reset` (they do the exact same thing)
- If the user has the marvelous idea of deleting folders while the application is running, it will automatically reset the configuration (and thus create new folders).