### PR TITLE
Fixed config reloading with backups.

### DIFF
--- a/src/main/kotlin/io/slama/core/config.kt
+++ b/src/main/kotlin/io/slama/core/config.kt
@@ -6,15 +6,16 @@ import io.slama.core.ConfigFolders.CONFIG_ROOT
 import io.slama.core.ConfigFolders.DATA_ROOT
 import io.slama.core.ConfigFolders.GUILD_CONFIG_ROOT
 import io.slama.core.ConfigFolders.POLLS_DATA_ROOT
+import java.io.File
+import java.io.IOException
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import net.dv8tion.jda.api.entities.Activity
 import net.dv8tion.jda.api.interactions.components.ButtonStyle
 import org.slf4j.LoggerFactory
-import java.io.File
-import java.io.IOException
 
 private val logger = LoggerFactory.getLogger("Configuration")
 
@@ -36,19 +37,19 @@ class BotConfiguration private constructor() {
             because it can only happen if the JVM is literally dying
             */
 
-        val shusher: ShusherConfig
+        val shusher: ShusherConfig?
             get() = innerConfig!!.shusherConfig /*
             Explicitly want an NPE if it's null here,
             because it can only happen if the JVM is literally dying
             */
 
-        val presence: PresenceConfig
+        val presence: PresenceConfig?
             get() = innerConfig!!.presenceConfig /*
             Explicitly want an NPE if it's null here,
             because it can only happen if the JVM is literally dying
             */
 
-        val mail: MailConfig
+        val mail: MailConfig?
             get() = innerConfig!!.mailConfig /*
             Explicitly want an NPE if it's null here,
             because it can only happen if the JVM is literally dying
@@ -61,7 +62,16 @@ class BotConfiguration private constructor() {
                 return field
             }
 
+        private var backupGuilds: GuildConfigManager? = null
+        private var backupShusher: ShusherConfig? = null
+        private var backupPresence: PresenceConfig? = null
+        private var backupMail: MailConfig? = null
+
         fun resetConfig() {
+            backupGuilds = guilds
+            backupShusher = shusher
+            backupPresence = presence
+            backupMail = mail
             setup()
             innerConfig = null
         }
@@ -178,7 +188,20 @@ class BotConfiguration private constructor() {
         private val guildConfigsMap: MutableMap<Long, GuildConfig> = mutableMapOf()
 
         operator fun get(guildId: Long): GuildConfig? {
-            if (guildId !in guildConfigsMap.keys) loadConfig(guildId)
+            if (guildId !in guildConfigsMap.keys) {
+                val old = backupGuilds?.guildConfigsMap?.get(guildId)
+                try {
+                    loadConfig(guildId)
+                } catch (e: SerializationException) {
+                    logger.warn("Failed to load guild config for guild $guildId. Using backup")
+                    if (old != null) {
+                        guildConfigsMap[guildId] = old
+                    } else {
+                        logger.error("No backup for guild $guildId. Guild will be ignored")
+                        return null
+                    }
+                }
+            }
             return guildConfigsMap[guildId]
         }
 
@@ -209,12 +232,12 @@ class BotConfiguration private constructor() {
                 createAutorolesFile(autorolesF)
             }
 
-            logger.info("Loaded config of guild $guildId")
             guildConfigsMap[guildId] = GuildConfig(
                 Json.decodeFromString(rolesF.readText()),
                 Json.decodeFromString(channelsF.readText()),
                 Json.decodeFromString(autorolesF.readText()),
             )
+            logger.info("Loaded config of guild $guildId")
         }
     }
 
@@ -223,7 +246,7 @@ class BotConfiguration private constructor() {
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    private val shusherConfig: ShusherConfig by lazy {
+    private val shusherConfig: ShusherConfig? by lazy {
         with(File(CONFIG_ROOT)) {
             if (!exists() || !isDirectory)
                 resetConfig()
@@ -232,12 +255,25 @@ class BotConfiguration private constructor() {
         if (!shusherF.exists()) {
             createShusherFile(shusherF)
         }
-        logger.info("Loaded shusher config")
-        Json.decodeFromString(shusherF.readText())
+
+        var config: ShusherConfig?
+        try {
+            config = Json.decodeFromString(shusherF.readText())
+            logger.info("Loaded shusher config")
+        } catch (e: SerializationException) {
+            logger.warn("Failed to load shusher config. Using backup")
+            config = if (backupShusher != null) {
+                backupShusher
+            } else {
+                logger.warn("No backup for shusher config. Using default")
+                null
+            }
+        }
+        config
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    private val presenceConfig: PresenceConfig by lazy {
+    private val presenceConfig: PresenceConfig? by lazy {
         with(File(CONFIG_ROOT)) {
             if (!exists() || !isDirectory)
                 resetConfig()
@@ -246,12 +282,24 @@ class BotConfiguration private constructor() {
         if (!presenceF.exists()) {
             createPresenceFile(presenceF)
         }
-        logger.info("Loaded presence config")
-        Json.decodeFromString(presenceF.readText())
+        var config: PresenceConfig?
+        try {
+            config = Json.decodeFromString(presenceF.readText())
+            logger.info("Loaded presence config")
+        } catch (e: SerializationException) {
+            logger.warn("Failed to load presence config. Using backup")
+            config = if (backupPresence != null) {
+                backupPresence
+            } else {
+                logger.warn("No backup for presence config. Using default")
+                null
+            }
+        }
+        config
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    private val mailConfig: MailConfig by lazy {
+    private val mailConfig: MailConfig? by lazy {
         with(File(CONFIG_ROOT)) {
             if (!exists() || !isDirectory)
                 resetConfig()
@@ -260,8 +308,20 @@ class BotConfiguration private constructor() {
         if (!mailF.exists()) {
             createMailFile(mailF)
         }
-        logger.info("Loaded mail config")
-        Json.decodeFromString(mailF.readText())
+        var config: MailConfig?
+        try {
+            config = Json.decodeFromString(mailF.readText())
+            logger.info("Loaded mail config")
+        } catch (e: SerializationException) {
+            logger.warn("Failed to load mail config. Using backup.")
+            config = if (backupMail != null) {
+                backupMail
+            } else {
+                logger.error("No backup for mail config. Mail functionality will be disabled.")
+                null
+            }
+        }
+        config
     }
 }
 

--- a/src/main/kotlin/io/slama/core/config.kt
+++ b/src/main/kotlin/io/slama/core/config.kt
@@ -6,8 +6,6 @@ import io.slama.core.ConfigFolders.CONFIG_ROOT
 import io.slama.core.ConfigFolders.DATA_ROOT
 import io.slama.core.ConfigFolders.GUILD_CONFIG_ROOT
 import io.slama.core.ConfigFolders.POLLS_DATA_ROOT
-import java.io.File
-import java.io.IOException
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
@@ -16,6 +14,8 @@ import kotlinx.serialization.json.Json
 import net.dv8tion.jda.api.entities.Activity
 import net.dv8tion.jda.api.interactions.components.ButtonStyle
 import org.slf4j.LoggerFactory
+import java.io.File
+import java.io.IOException
 
 private val logger = LoggerFactory.getLogger("Configuration")
 

--- a/src/main/kotlin/io/slama/events/shusher.kt
+++ b/src/main/kotlin/io/slama/events/shusher.kt
@@ -3,8 +3,6 @@ package io.slama.events
 import io.slama.core.BotConfiguration
 import io.slama.core.ConfigFolders
 import io.slama.utils.isAdmin
-import java.io.File
-import kotlin.random.Random
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Role
@@ -12,6 +10,8 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.io.File
+import kotlin.random.Random
 
 private const val SHUSHER_TRIGGER_THRESHOLD = .009
 private const val SHUSHER_FILE = "shusherRolesIds"

--- a/src/main/kotlin/io/slama/events/shusher.kt
+++ b/src/main/kotlin/io/slama/events/shusher.kt
@@ -3,6 +3,8 @@ package io.slama.events
 import io.slama.core.BotConfiguration
 import io.slama.core.ConfigFolders
 import io.slama.utils.isAdmin
+import java.io.File
+import kotlin.random.Random
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Role
@@ -10,8 +12,6 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.io.File
-import kotlin.random.Random
 
 private const val SHUSHER_TRIGGER_THRESHOLD = .009
 private const val SHUSHER_FILE = "shusherRolesIds"
@@ -49,7 +49,8 @@ class Shusher(
 
             if (member.roles.map { it.id }.any { roles[event.guild.id] == it }) {
                 if (random.nextFloat() <= SHUSHER_TRIGGER_THRESHOLD) {
-                    event.channel.sendMessage(BotConfiguration.shusher.sentences.random()).queue()
+                    val sentence = BotConfiguration.shusher?.sentences?.random() ?: "Please stop talking..."
+                    event.channel.sendMessage(sentence).queue()
                 }
             }
         }

--- a/src/main/kotlin/io/slama/main.kt
+++ b/src/main/kotlin/io/slama/main.kt
@@ -17,10 +17,6 @@ import io.slama.events.clearAutoRoles
 import io.slama.events.loadAutoRoles
 import io.slama.managers.MailManager
 import io.slama.utils.TaskScheduler
-import java.io.File
-import java.util.concurrent.TimeUnit
-import javax.security.auth.login.LoginException
-import kotlin.system.exitProcess
 import kotlinx.coroutines.Job
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.entities.Activity
@@ -30,6 +26,10 @@ import net.dv8tion.jda.api.requests.GatewayIntent
 import net.dv8tion.jda.api.utils.ChunkingFilter
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.io.File
+import java.util.concurrent.TimeUnit
+import javax.security.auth.login.LoginException
+import kotlin.system.exitProcess
 
 private val logger: Logger = LoggerFactory.getLogger("UGEBot")
 private val token = Key("token", stringType)

--- a/src/main/kotlin/io/slama/main.kt
+++ b/src/main/kotlin/io/slama/main.kt
@@ -17,6 +17,11 @@ import io.slama.events.clearAutoRoles
 import io.slama.events.loadAutoRoles
 import io.slama.managers.MailManager
 import io.slama.utils.TaskScheduler
+import java.io.File
+import java.util.concurrent.TimeUnit
+import javax.security.auth.login.LoginException
+import kotlin.system.exitProcess
+import kotlinx.coroutines.Job
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.entities.Activity
 import net.dv8tion.jda.api.events.ReadyEvent
@@ -25,10 +30,6 @@ import net.dv8tion.jda.api.requests.GatewayIntent
 import net.dv8tion.jda.api.utils.ChunkingFilter
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.io.File
-import java.util.concurrent.TimeUnit
-import javax.security.auth.login.LoginException
-import kotlin.system.exitProcess
 
 private val logger: Logger = LoggerFactory.getLogger("UGEBot")
 private val token = Key("token", stringType)
@@ -47,25 +48,27 @@ class UGEBot(token: String) : ListenerAdapter() {
         exitProcess(1)
     }
 
-    private lateinit var mailManager: MailManager
+    private var mailManager: MailManager? = null
+
+    private var presenceJob: Job? = null
 
     init {
         while (true) {
             val command = readLine()?.split(" ") ?: listOf("default")
             when (command[0]) {
                 "die" -> {
-                    mailManager.close()
+                    mailManager?.close()
                     jda.shutdown()
                     exitProcess(0)
                 }
                 "reload", "reset" -> {
                     logger.warn("Reload is not reliable, consider restarting the bot if you encounter issues")
-                    mailManager.close()
+                    mailManager?.close()
                     load()
                     logger.info("Reload complete!")
                 }
-                "mail-close" -> mailManager.close()
-                "mail-open" -> mailManager.reOpen()
+                "mail-close" -> mailManager?.close()
+                "mail-open" -> mailManager?.reOpen()
                 "delete-commands" -> {
                     if (command.size < 2) continue
                     command.drop(1).forEach { name ->
@@ -93,16 +96,12 @@ class UGEBot(token: String) : ListenerAdapter() {
         )
         Shusher(jda)
         load()
-        TaskScheduler.repeat(10, TimeUnit.MINUTES) {
-            val (message, type) = BotConfiguration.presence.messages.entries.random()
-            jda.presence.setPresence(Activity.of(type, message), false)
-            true
-        }
     }
 
     private fun load() {
         BotConfiguration.resetConfig()
-        mailManager = MailManager(BotConfiguration.mail, jda)
+        val mailConfig = BotConfiguration.mail
+        if (mailConfig != null) mailManager = MailManager(mailConfig, jda)
         clearAutoRoles()
         jda.registerGlobalCommands()
         jda.guilds.forEach {
@@ -110,6 +109,13 @@ class UGEBot(token: String) : ListenerAdapter() {
             it.registerGuildCommands()
         }
         logger.info("Registered commands")
+        presenceJob?.cancel()
+        presenceJob = TaskScheduler.repeat(10, TimeUnit.MINUTES) {
+            val (message, type) = BotConfiguration.presence?.messages?.entries?.random()
+                .let { "Nothing" to Activity.ActivityType.DEFAULT }
+            jda.presence.setPresence(Activity.of(type, message), false)
+            true
+        }
     }
 
     private fun deleteCommandByName(name: String) {


### PR DESCRIPTION
Closes #79 

When a subconfig is invalid, the previous one will be used (if only the presence configuration is wrong, then it'll be the only one to be rolled back). If a config has no backup, the following will happen :
- shusher : uses default "Please stop talking..."
- presence : uses default "Playing Nothing"
- guilds (by guild) : !!! the guild will be ignored
- mail : !!! the mail functionalities will be disabled